### PR TITLE
Se corrigio el refresh que habia al ver detalles charola

### DIFF
--- a/tech_nebrios_tracker/lib/framework/views/charolasDashboardView.dart
+++ b/tech_nebrios_tracker/lib/framework/views/charolasDashboardView.dart
@@ -260,7 +260,10 @@ class VistaCharolas extends StatelessWidget {
                                       "${charola.fechaCreacion.day}/${charola.fechaCreacion.month}/${charola.fechaCreacion.year}",
                                   nombreCharola: charola.nombreCharola,
                                   color: obtenerColorPorNombre(charola.nombreCharola),
-                                  onTap: () => onVerDetalle(charola.charolaId),
+                                  onTap: () async { 
+                                    await context.read<CharolaViewModel>().cargarCharola(charola.charolaId);
+                                    onVerDetalle(charola.charolaId);
+                                  },
                                 ),
                               );
                             },

--- a/tech_nebrios_tracker/lib/framework/views/detalleCharolaView.dart
+++ b/tech_nebrios_tracker/lib/framework/views/detalleCharolaView.dart
@@ -189,14 +189,12 @@ class _PantallaCharolaState extends State<PantallaCharola> {
                                                       reset: true,
                                                     );
                                                     widget.onRegresar(); // <- Vuelve al dashboard limpiamente
-                                                    ScaffoldMessenger.of(context).showSnackBar(
-                                                      const SnackBar(content: Text('Charola eliminada con éxito')),
-                                                    );
                                                     Navigator.of(context).pop();
                                                     ScaffoldMessenger.of(
                                                       context,
                                                     ).showSnackBar(
                                                       const SnackBar(
+                                                        backgroundColor:Colors.green,
                                                         content: Text(
                                                           'Charola eliminada con éxito',
                                                         ),


### PR DESCRIPTION
## Plantilla PR FrontEnd

Última actualización 28/04/25

---

# Descripción

Al cargar el menú de charolas había que hacer doble clic para que cargara la pantalla correctamente y al arreglar eso no eliminaba las charolas.
---

## Tipo de cambio

- [x] Corrección de error (cambio no disruptivo que soluciona un problema)
- [ ] Nueva función (cambio no disruptivo que agrega funcionalidad)
- [ ] Cambio disruptivo (corrección o función que afecta la compatibilidad existente)
- [ ] Este cambio requiere una actualización en la documentación
- [ ] Camio mínimo (Visual o de bajo impacto, sin afectcar lógica )

---

# ¿Cómo se ha probado?

Describe resumidamente cómo lo probaste y funciona. Ejemplo:

- "Se probó manualmente. Se validó que el botón 'Eliminar' elimina correctamente la información y se muestra una alerta de éxito."
  _En caso de cambio mínimo:_
- "El cambio fue visualmente unicamente (color del boton). Se validó en los navegadores principales. No se requirieron pruebas funcionales."

---

### Cambios menores

- [ ] Este PR realiza un cambio mínimo que no afecta la lógica del sistema
- [x] Se validó visualmente el componente afectado
- [x] No se realizaron pruebas unitarias porque no aplica
