### PR TITLE
Se corrigio el nombre del PRODUCT_NAME en macos

### DIFF
--- a/tech_nebrios_tracker/macos/Runner/Configs/AppInfo.xcconfig
+++ b/tech_nebrios_tracker/macos/Runner/Configs/AppInfo.xcconfig
@@ -5,10 +5,10 @@
 // 'flutter create' template.
 
 // The application's name. By default this is also the title of the Flutter window.
-PRODUCT_NAME = tech_nebrios_tracker
+PRODUCT_NAME = Zuustento Tracker
 
 // The application's bundle identifier
 PRODUCT_BUNDLE_IDENTIFIER = com.example.techNebriosTracker
 
 // The copyright displayed in application information
-PRODUCT_COPYRIGHT = Copyright © 2025 com.example. All rights reserved.
+PRODUCT_COPYRIGHT = Copyright © 2025 Code&Co. All rights reserved.


### PR DESCRIPTION
## Plantilla PR FrontEnd

Última actualización 28/04/25

---

# Descripción
Se corrigió el PRODUCT_NAME en la app de macOS

---

## Tipo de cambio

- [x] Corrección de error (cambio no disruptivo que soluciona un problema)
- [ ] Nueva función (cambio no disruptivo que agrega funcionalidad)
- [ ] Cambio disruptivo (corrección o función que afecta la compatibilidad existente)
- [ ] Este cambio requiere una actualización en la documentación
- [ ] Camio mínimo (Visual o de bajo impacto, sin afectcar lógica )

---

# ¿Cómo se ha probado?

- Se probo accediendo al "About Zuustento tracker" en la configuracion de la app 

---

### Cambios menores

- [ ] Este PR realiza un cambio mínimo que no afecta la lógica del sistema
- [ ] Se validó visualmente el componente afectado
- [ ] No se realizaron pruebas unitarias porque no aplica

---
