### PR TITLE
no se modifican las charolas pasadas

### DIFF
--- a/tech_nebrios_tracker/lib/framework/views/editarCharolaView.dart
+++ b/tech_nebrios_tracker/lib/framework/views/editarCharolaView.dart
@@ -87,6 +87,21 @@ void mostrarPopUpEditarCharola({
                           children: [
                             const Divider(height: 1),
                             const SizedBox(height: 30),
+
+                            if (editarViewModel.estadoController.text == "pasada") ...[
+                              Center(
+                                child: _buildDropdownFormField(
+                                  label: "Estado",
+                                  items: ["activa", "pasada"],
+                                  value: editarViewModel.estadoController.text,
+                                  onChanged: (value) {
+                                    editarViewModel.estadoController.text = value!;
+                                  },
+                                  validator: (v) => v == null ? 'Selecciona un estado' : null,
+                                ),
+                              ),
+                            ] else ...[
+
                             Row(
                               crossAxisAlignment: CrossAxisAlignment.start,
                               children: [
@@ -224,8 +239,7 @@ void mostrarPopUpEditarCharola({
                                     _buildDropdownFormField(
                                       label: "Estado",
                                       items: ["activa", "pasada"],
-                                      value:
-                                          editarViewModel.estadoController.text,
+                                      value: editarViewModel.estadoController.text,
                                       onChanged: (value) {
                                         editarViewModel.estadoController.text =
                                             value!;
@@ -303,6 +317,8 @@ void mostrarPopUpEditarCharola({
                                 ),
                               ],
                             ),
+                            
+                            ],
                           ],
                         ),
                       ),
@@ -347,7 +363,7 @@ void mostrarPopUpEditarCharola({
                                       ),
                                     ),
                                     child: const Text(
-                                      'Editar información',
+                                      'Editar',
                                       style: TextStyle(
                                         color: Colors.white,
                                         fontSize: 20,
@@ -361,6 +377,7 @@ void mostrarPopUpEditarCharola({
                                         vm.resetForm();
                                         Navigator.of(dialogContext).pop();
                                         vm.cargarCharola(charolaId);
+                                        vm.cargarCharolas();
 
                                         ScaffoldMessenger.of(
                                           context,


### PR DESCRIPTION
## No se modifican las charolas pasadas

Última actualización 28/04/25

---

# Descripción
Correcciones: 
- no se modifican las charolas pasadas
- boton editar charola -> editar
- se refresca la pantalla de menu despues de cambiar el estado

---

## Tipo de cambio

- [x] Corrección de error (cambio no disruptivo que soluciona un problema)
- [ ] Nueva función (cambio no disruptivo que agrega funcionalidad)
- [ ] Cambio disruptivo (corrección o función que afecta la compatibilidad existente)
- [ ] Este cambio requiere una actualización en la documentación
- [x] Camio mínimo (Visual o de bajo impacto, sin afectcar lógica )

---

# ¿Cómo se ha probado?

Describe resumidamente cómo lo probaste y funciona. Ejemplo:

- Se probó manualmente al ver que todo funcionaba 

---

### Cambios menores

- [ ] Este PR realiza un cambio mínimo que no afecta la lógica del sistema
- [ ] Se validó visualmente el componente afectado
- [ ] No se realizaron pruebas unitarias porque no aplica

---

Versión: V1
### Autores

| Nombre                         | Rol   |
| ------------------------------ | ----- |
| Juan Eduardo Rosas Cerón  | Autor |