### PR TITLE
Añadir mensaje de error para alimento en charola

### DIFF
--- a/tech_nebrios_tracker/lib/framework/viewmodels/alimentacionViewModel.dart
+++ b/tech_nebrios_tracker/lib/framework/viewmodels/alimentacionViewModel.dart
@@ -90,6 +90,8 @@ class AlimentacionViewModel extends ChangeNotifier {
           ? '🌐 101: Problemas de red'
           : e.toString().contains('400')
           ? '❌ 400: Datos no válidos'
+          : e.toString().contains('409')
+          ? '❌ No se puede eliminar el alimento porque está asignado a una charola'
           : '💥 Error de conexión';
 
       _logger.e(msg);


### PR DESCRIPTION
## Plantilla PR FrontEnd

Última actualización 28/04/25

---

# Descripción
- Se añadió el mensaje de retroalimentación para el usuario al intentar eliminar un alimento que está asociado a una charola activa.
---

## Tipo de cambio

- [x] Corrección de error (cambio no disruptivo que soluciona un problema)
- [ ] Nueva función (cambio no disruptivo que agrega funcionalidad)
- [ ] Cambio disruptivo (corrección o función que afecta la compatibilidad existente)
- [ ] Este cambio requiere una actualización en la documentación
- [ ] Camio mínimo (Visual o de bajo impacto, sin afectcar lógica )

---

# ¿Cómo se ha probado?

Describe resumidamente cómo lo probaste y funciona:

- Se probó visualmente que al intentar eliminar un alimento asociado a una charola activa, se desplegára el mensaje de error.

---

### Cambios menores

- [x] Este PR realiza un cambio mínimo que no afecta la lógica del sistema
- [x] Se validó visualmente el componente afectado
- [x] No se realizaron pruebas unitarias porque no aplica
