### PR TITLE
Bugfix/jalv r20 recargar dropdowns

### DIFF
--- a/tech_nebrios_tracker/lib/framework/viewmodels/alimentacionViewModel.dart
+++ b/tech_nebrios_tracker/lib/framework/viewmodels/alimentacionViewModel.dart
@@ -143,8 +143,8 @@ class AlimentacionViewModel extends ChangeNotifier {
     if (nombre.trim().isEmpty || descripcion.trim().isEmpty) {
       return 'Nombre y descripción no pueden estar vacíos.';
     }
-    if (nombre.length > 25) {
-      return 'El nombre no puede tener más de 25 caracteres.';
+    if (nombre.length > 20) {
+      return 'El nombre no puede tener más de 20 caracteres.';
     }
     if (descripcion.length > 200) {
       return 'La descripción no puede tener más de 200 caracteres.';

--- a/tech_nebrios_tracker/lib/framework/viewmodels/tamizarCharolaViewmodel.dart
+++ b/tech_nebrios_tracker/lib/framework/viewmodels/tamizarCharolaViewmodel.dart
@@ -151,10 +151,8 @@ class TamizadoViewModel extends ChangeNotifier {
   }
 
   Future<void> cargarAlimentos() async {
-    if (_alimentosCargados) return; // Evita cargar los datos más de una vez
     try {
       alimentos = await _alimentoRepo.obtenerAlimentos();
-      _alimentosCargados = true; // Marca los datos como cargados
       notifyListeners(); // Notifica a la vista que los datos han cambiado
     } catch (e) {
       _logger.e('Error al cargar los alimentos: $e');
@@ -162,10 +160,8 @@ class TamizadoViewModel extends ChangeNotifier {
   }
 
   Future<void> cargarHidratacion() async {
-    if (_hidratacionCargados) return; // Evita cargar los datos más de una vez
     try {
       hidratacion = await _hidratacionRepo.obtenerHidratacion();
-      _hidratacionCargados = true; // Marca los datos como cargados
       notifyListeners(); // Notifica a la vista que los datos han cambiado
     } catch (e) {
       _logger.e('Error al cargar la hidratación: $e');

--- a/tech_nebrios_tracker/lib/framework/views/alimentacionView.dart
+++ b/tech_nebrios_tracker/lib/framework/views/alimentacionView.dart
@@ -298,7 +298,7 @@ class _AlimentacionScreenState extends State<AlimentacionScreen> {
                         controller: nombreController,
                         maxLength: 20,
                         decoration: const InputDecoration(
-                          labelText: 'Nombre:',
+                          labelText: 'Nombre',
                           border: OutlineInputBorder(),
                         ),
                       ),
@@ -307,7 +307,7 @@ class _AlimentacionScreenState extends State<AlimentacionScreen> {
                         controller: descripcionController,
                         maxLength: 200,
                         decoration: const InputDecoration(
-                          labelText: 'Descripción:',
+                          labelText: 'Descripción',
                           border: OutlineInputBorder(),
                         ),
                         maxLines: null,
@@ -426,7 +426,7 @@ class _AlimentacionScreenState extends State<AlimentacionScreen> {
                         controller: nombreController,
                         maxLength: 20,
                         decoration: const InputDecoration(
-                          labelText: 'Nombre:',
+                          labelText: 'Nombre',
                           border: OutlineInputBorder(),
                         ),
                       ),
@@ -435,7 +435,7 @@ class _AlimentacionScreenState extends State<AlimentacionScreen> {
                         controller: descripcionController,
                         maxLength: 200,
                         decoration: const InputDecoration(
-                          labelText: 'Descripción:',
+                          labelText: 'Descripción',
                           border: OutlineInputBorder(),
                         ),
                         maxLines: null,

--- a/tech_nebrios_tracker/lib/framework/views/alimentacionView.dart
+++ b/tech_nebrios_tracker/lib/framework/views/alimentacionView.dart
@@ -296,7 +296,7 @@ class _AlimentacionScreenState extends State<AlimentacionScreen> {
                       const SizedBox(height: 30),
                       TextField(
                         controller: nombreController,
-                        maxLength: 25,
+                        maxLength: 20,
                         decoration: const InputDecoration(
                           labelText: 'Nombre:',
                           border: OutlineInputBorder(),
@@ -424,7 +424,7 @@ class _AlimentacionScreenState extends State<AlimentacionScreen> {
                       const SizedBox(height: 30),
                       TextField(
                         controller: nombreController,
-                        maxLength: 25,
+                        maxLength: 20,
                         decoration: const InputDecoration(
                           labelText: 'Nombre:',
                           border: OutlineInputBorder(),

--- a/tech_nebrios_tracker/lib/framework/views/tamizarCharolaIndividualView.dart
+++ b/tech_nebrios_tracker/lib/framework/views/tamizarCharolaIndividualView.dart
@@ -104,6 +104,16 @@ class _VistaTamizadoIndividualState extends State<VistaTamizadoIndividual> {
   final List<modelo.CharolaRegistro> nuevasCharolas = [];
   final formKey2 = GlobalKey<FormState>();
 
+  late TamizadoViewModel viewModel;
+
+  @override
+  void initState() {
+    super.initState();
+    viewModel = Provider.of<TamizadoViewModel>(context, listen: false);
+    viewModel.cargarAlimentos();
+    viewModel.cargarHidratacion();
+  }
+
   @override
   Widget build(BuildContext context) {
     final charolaVM = Provider.of<CharolaViewModel>(context);


### PR DESCRIPTION
## Plantilla PR FrontEnd

Última actualización 28/04/25

---

# Descripción
- Se eliminaron los ':' innecesarios de los pop-ups de alimento.
- Se corrigió el error que no permitia que se recargaran los dropdowns de la vista de tamizado individual.
- Se ajusto el límite de caracteres en registrar alimento.
---

## Tipo de cambio

- [x] Corrección de error (cambio no disruptivo que soluciona un problema)
- [ ] Nueva función (cambio no disruptivo que agrega funcionalidad)
- [ ] Cambio disruptivo (corrección o función que afecta la compatibilidad existente)
- [ ] Este cambio requiere una actualización en la documentación
- [ ] Camio mínimo (Visual o de bajo impacto, sin afectcar lógica )

---

# ¿Cómo se ha probado?

Describe resumidamente cómo lo probaste y funciona. Ejemplo:

- Se probó visualmente que los dropdowns se recargaran al entrar a la vista de tamizado individual.
- Se probó el límite de caracteres.

---

### Cambios menores

- [x] Este PR realiza un cambio mínimo que no afecta la lógica del sistema
- [x] Se validó visualmente el componente afectado
- [x] No se realizaron pruebas unitarias porque no aplica
